### PR TITLE
Implement a classpath scanner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,5 +251,10 @@
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.reflections</groupId>
+      <artifactId>reflections</artifactId>
+      <version>0.9.11</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
+++ b/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
@@ -8,17 +8,20 @@
 package org.opendaylight.genius.simple;
 
 import com.google.inject.AbstractModule;
-import org.opendaylight.genius.alivenessmonitor.internal.AlivenessMonitor;
-import org.opendaylight.genius.alivenessmonitor.protocols.AlivenessProtocolHandlerRegistry;
-import org.opendaylight.genius.alivenessmonitor.protocols.impl.AlivenessProtocolHandlerRegistryImpl;
+import org.opendaylight.infrautils.inject.ClassPathScanner;
 import org.opendaylight.yang.gen.v1.urn.opendaylight.genius.alivenessmonitor.rev160411.AlivenessMonitorService;
 
 public class AlivenessMonitorWiring extends AbstractModule {
 
+    private final ClassPathScanner scanner;
+
+    public AlivenessMonitorWiring(ClassPathScanner scanner) {
+        this.scanner = scanner;
+    }
+
     @Override
     protected void configure() {
-        bind(AlivenessMonitorService.class).to(AlivenessMonitor.class);
-        bind(AlivenessProtocolHandlerRegistry.class).to(AlivenessProtocolHandlerRegistryImpl.class);
+        scanner.bind(binder(), AlivenessMonitorService.class);
     }
 
 }

--- a/src/main/java/org/opendaylight/genius/simple/GeniusMain.java
+++ b/src/main/java/org/opendaylight/genius/simple/GeniusMain.java
@@ -7,6 +7,7 @@
  */
 package org.opendaylight.genius.simple;
 
+import org.opendaylight.infrautils.inject.ClassPathScanner;
 import org.opendaylight.infrautils.simple.ShellMain;
 
 public final class GeniusMain {
@@ -14,7 +15,8 @@ public final class GeniusMain {
     private GeniusMain() { }
 
     public static void main(String[] args) {
-        new ShellMain(new GeniusWiring()).awaitShutdown();
+        ClassPathScanner scanner = new ClassPathScanner("org.opendaylight");
+        new ShellMain(new GeniusWiring(scanner)).awaitShutdown();
     }
 
 }

--- a/src/main/java/org/opendaylight/genius/simple/GeniusWiring.java
+++ b/src/main/java/org/opendaylight/genius/simple/GeniusWiring.java
@@ -9,6 +9,7 @@ package org.opendaylight.genius.simple;
 
 import com.google.inject.AbstractModule;
 import org.opendaylight.daexim.DataImportBootReady;
+import org.opendaylight.infrautils.inject.ClassPathScanner;
 import org.opendaylight.infrautils.inject.guice.testutils.AnnotationsModule;
 import org.opendaylight.infrautils.simple.InfraUtilsWiring;
 import org.opendaylight.mdsal.simple.MdsalWiring;
@@ -17,6 +18,12 @@ import org.opendaylight.serviceutils.simple.ServiceUtilsWiring;
 import org.ops4j.pax.cdi.api.OsgiService;
 
 public class GeniusWiring extends AbstractModule {
+
+    private final ClassPathScanner scanner;
+
+    public GeniusWiring(ClassPathScanner scanner) {
+        this.scanner = scanner;
+    }
 
     @Override
     protected void configure() {
@@ -43,7 +50,7 @@ public class GeniusWiring extends AbstractModule {
         install(new MdsalUtilWiring());
         install(new LockManagerWiring());
         install(new IdManagerWiring());
-        install(new AlivenessMonitorWiring());
+        install(new AlivenessMonitorWiring(scanner));
         install(new InterfaceManagerWiring());
         install(new ItmWiring());
         install(new DatastoreUtilsWiring());

--- a/src/main/java/org/opendaylight/infrautils/inject/ClassPathScanner.java
+++ b/src/main/java/org/opendaylight/infrautils/inject/ClassPathScanner.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2018 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.opendaylight.infrautils.inject;
+
+import com.google.inject.Binder;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class path scanner designed to be used with Guice. This provides a way for modules to request the bindings they
+ * need by scanning the class path; bindings are processed recursively on {@link Singleton} constructors, for all
+ * all {@link Inject}-annotated constructors.
+ * <p>
+ * Implementations are only mapped to interfaces for which they are the sole available implementation. If the class
+ * path contains multiple implementations of a requested interface, the scanner won’t bind any of them, and the
+ * caller will have to bind one explicitly.
+ */
+public class ClassPathScanner {
+    private static final Logger LOG = LoggerFactory.getLogger(ClassPathScanner.class);
+
+    private final Map<Class, Class> implementations = new HashMap<>();
+
+    /**
+     * Create a class path scanner, scanning packages with the given prefix.
+     *
+     * @param prefix The package prefix.
+     */
+    public ClassPathScanner(String prefix) {
+        Reflections reflections = new Reflections(prefix);
+        Set<Class<?>> duplicateInterfaces = new HashSet<>();
+        for (Class<?> singleton : reflections.getTypesAnnotatedWith(Singleton.class)) {
+            for (Class<?> declaredInterface : singleton.getInterfaces()) {
+                if (!duplicateInterfaces.contains(declaredInterface)) {
+                    if (implementations.put(declaredInterface, singleton) != null) {
+                        LOG.warn("{} is declared multiple times, ignoring it", declaredInterface);
+                        implementations.remove(declaredInterface);
+                        duplicateInterfaces.add(declaredInterface);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Binds the given interfaces in the given binder, using implementations discovered by scanning the class path.
+     *
+     * @param binder The binder.
+     * @param interfaces The requested interfaces.
+     */
+    public void bind(Binder binder, Class... interfaces) {
+        for (Class requestedInterface : interfaces) {
+            bindImplementationFor(binder, requestedInterface);
+        }
+        // TODO Perhaps return interfaces which weren’t bound?
+    }
+
+    private void bindImplementationFor(Binder binder, Class requestedInterface) {
+        Class implementation = implementations.get(requestedInterface);
+        if (implementation != null) {
+            binder.bind(requestedInterface).to(implementation);
+            for (Constructor constructor : implementation.getDeclaredConstructors()) {
+                Annotation injectAnnotation = constructor.getAnnotation(Inject.class);
+                if (injectAnnotation != null) {
+                    for (Class parameterType : constructor.getParameterTypes()) {
+                        bindImplementationFor(binder, parameterType);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/opendaylight/netvirt/simple/NetvirtMain.java
+++ b/src/main/java/org/opendaylight/netvirt/simple/NetvirtMain.java
@@ -7,6 +7,7 @@
  */
 package org.opendaylight.netvirt.simple;
 
+import org.opendaylight.infrautils.inject.ClassPathScanner;
 import org.opendaylight.infrautils.simple.Main;
 
 public final class NetvirtMain {
@@ -14,7 +15,8 @@ public final class NetvirtMain {
     private NetvirtMain() { }
 
     public static void main(String[] args) {
-        new Main(new NetvirtWiring()).awaitShutdown();
+        ClassPathScanner scanner = new ClassPathScanner("org.opendaylight");
+        new Main(new NetvirtWiring(scanner)).awaitShutdown();
     }
 
 }

--- a/src/main/java/org/opendaylight/netvirt/simple/NetvirtWiring.java
+++ b/src/main/java/org/opendaylight/netvirt/simple/NetvirtWiring.java
@@ -9,12 +9,19 @@ package org.opendaylight.netvirt.simple;
 
 import com.google.inject.AbstractModule;
 import org.opendaylight.genius.simple.GeniusWiring;
+import org.opendaylight.infrautils.inject.ClassPathScanner;
 
 public class NetvirtWiring extends AbstractModule {
 
+    private final ClassPathScanner scanner;
+
+    public NetvirtWiring(ClassPathScanner scanner) {
+        this.scanner = scanner;
+    }
+
     @Override
     protected void configure() {
-        install(new GeniusWiring());
+        install(new GeniusWiring(scanner));
 
         install(new AclServiceWiring());
     }


### PR DESCRIPTION
The approach used here is to allow modules to request bindings for
interfaces to implementations found by scanning the class path, as
long as only one such implementation is found. This allows modules to
bind by requesting bindings for the main interface(s) they want to
provide, and re-use the annotation-based information contained in
their implementations and their dependencies.

Signed-off-by: Stephen Kitt <skitt@redhat.com>