### PR TITLE
make ClassPathScanner log "declared multiple times" debug instead warn

### DIFF
--- a/src/main/java/org/opendaylight/infrautils/inject/ClassPathScanner.java
+++ b/src/main/java/org/opendaylight/infrautils/inject/ClassPathScanner.java
@@ -47,7 +47,7 @@ public class ClassPathScanner {
             for (Class<?> declaredInterface : singleton.getInterfaces()) {
                 if (!duplicateInterfaces.contains(declaredInterface)) {
                     if (implementations.put(declaredInterface, singleton) != null) {
-                        LOG.warn("{} is declared multiple times, ignoring it", declaredInterface);
+                        LOG.debug("{} is declared multiple times, ignoring it", declaredInterface);
                         implementations.remove(declaredInterface);
                         duplicateInterfaces.add(declaredInterface);
                     }


### PR DESCRIPTION
@skitt OK with you?

This avoids seeing this, which is confusing and doesn't add much value:

```
2018-10-03T01:37:19,363 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.serviceutils.srm.ServiceRecoveryInterface is declared multiple times, ignoring it
2018-10-03T01:37:19,363 | WARN  | main             | ClassPathScanner                 | interface java.lang.AutoCloseable is declared multiple times, ignoring it
2018-10-03T01:37:19,364 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.yang.gen.v1.urn.opendaylight.packet.service.rev130709.PacketProcessingListener is declared multiple times, ignoring it
2018-10-03T01:37:19,364 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.serviceutils.srm.RecoverableListener is declared multiple times, ignoring it
2018-10-03T01:37:19,364 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.controller.md.sal.binding.api.ClusteredDataTreeChangeListener is declared multiple times, ignoring it
2018-10-03T01:37:19,364 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.yang.gen.v1.urn.opendaylight.flow.service.rev130819.SalFlowListener is declared multiple times, ignoring it
2018-10-03T01:37:19,364 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.mdsal.eos.binding.api.EntityOwnershipListener is declared multiple times, ignoring it
2018-10-03T01:37:19,365 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.netvirt.fibmanager.IVrfEntryHandler is declared multiple times, ignoring it
2018-10-03T01:37:19,365 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.infrautils.diagstatus.ServiceStatusProvider is declared multiple times, ignoring it
2018-10-03T01:37:19,365 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.yang.gen.v1.urn.opendaylight.genius.alivenessmonitor.rev160411.AlivenessMonitorListener is declared multiple times, ignoring it
2018-10-03T01:37:19,365 | WARN  | main             | ClassPathScanner                 | interface org.opendaylight.yang.gen.v1.urn.opendaylight.genius.arputil.rev160406.OdlArputilListener is declared multiple times, ignoring it
2018-10-03T01:37:19,365 | WARN  | main             | ClassPathScanner                 | interface java.lang.Runnable is declared multiple times, ignoring it
```