### PR TITLE
make ClassPathScannerTest use Guice instead of mocks

### DIFF
--- a/src/test/java/org/opendaylight/infrautils/inject/tests/ClassPathScannerTest.java
+++ b/src/test/java/org/opendaylight/infrautils/inject/tests/ClassPathScannerTest.java
@@ -7,76 +7,38 @@
  */
 package org.opendaylight.infrautils.inject.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
+import static com.google.common.truth.Truth.assertThat;
 
-import com.google.inject.Binder;
-import com.google.inject.binder.AnnotatedBindingBuilder;
-import com.google.inject.binder.ScopedBindingBuilder;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
-import org.junit.Before;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Stage;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.opendaylight.infrautils.inject.ClassPathScanner;
 
 public class ClassPathScannerTest {
-    private final TestBinder testBinder = mock(TestBinder.class, Mockito.CALLS_REAL_METHODS);
 
-    @Before
-    public void setup() {
-        new ClassPathScanner("org.opendaylight.infrautils.inject.tests").bind(testBinder,
-            ClassPathScannerTestTopInterface.class);
+    class TestModule extends AbstractModule {
+
+        final ClassPathScanner scanner;
+
+        TestModule(ClassPathScanner scanner) {
+            this.scanner = scanner;
+        }
+
+        @Override
+        protected void configure() {
+            scanner.bind(binder(), ClassPathScannerTestTopInterface.class);
+        }
     }
 
     @Test
     public void verifyImplementationBinding() {
-        assertEquals(ClassPathScannerTestImplementation.class,
-            testBinder.getImplementation(ClassPathScannerTestTopInterface.class));
-    }
+        Injector injector = Guice.createInjector(Stage.PRODUCTION,
+            new TestModule(
+                new ClassPathScanner("org.opendaylight.infrautils.inject.tests")));
 
-    private abstract static class TestBinder implements Binder {
-        private Map<Class<?>, Class<?>> bindings;
-
-        private <T> void storeBinding(Class<T> type, Class<? extends T> implementation) {
-            if (bindings == null) {
-                bindings = new HashMap<>();
-            }
-            bindings.put(type, implementation);
-        }
-
-        <T> Class<? extends T> getImplementation(Class<T> type) {
-            return (Class<? extends T>) bindings.get(type);
-        }
-
-        @Override
-        public <T> AnnotatedBindingBuilder<T> bind(Class<T> type) {
-            TestAnnotatedBindingBuilder builder = mock(TestAnnotatedBindingBuilder.class, CALLS_REAL_METHODS);
-            builder.setType(type);
-            builder.setBinder(this);
-            return builder;
-        }
-
-        private abstract static class TestAnnotatedBindingBuilder<T> implements AnnotatedBindingBuilder<T> {
-            private Class<T> type;
-            private TestBinder binder;
-
-            @Nullable
-            @Override
-            public ScopedBindingBuilder to(Class<? extends T> implementation) {
-                binder.storeBinding(type, implementation);
-                return null;
-            }
-
-            void setType(Class<T> type) {
-                this.type = type;
-            }
-
-            void setBinder(TestBinder binder) {
-                this.binder = binder;
-            }
-        }
+        assertThat(injector.getInstance(ClassPathScannerTestTopInterface.class))
+                .isInstanceOf(ClassPathScannerTestImplementation.class);
     }
 }


### PR DESCRIPTION
While this isn't a "unit" test anymore (because it uses Guice), it's
still fast enough, and at the same time serves to illustrates the real
use of ClassPathScanner.

TODO add test for the duplicateInterfaces stuff in ClassPathScanner.