### PR TITLE
intro. new bindAllSingletons()

### DIFF
--- a/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
+++ b/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
@@ -7,19 +7,12 @@
  */
 package org.opendaylight.genius.simple;
 
-import com.google.inject.AbstractModule;
+import org.opendaylight.infrautils.inject.guice.AutoWiringModule;
 import org.opendaylight.infrautils.inject.guice.GuiceClassPathBinder;
 
-public class AlivenessMonitorWiring extends AbstractModule {
-
-    private final GuiceClassPathBinder classPathBinder;
+public class AlivenessMonitorWiring extends AutoWiringModule {
 
     public AlivenessMonitorWiring(GuiceClassPathBinder classPathBinder) {
-        this.classPathBinder = classPathBinder;
-    }
-
-    @Override
-    protected void configure() {
-        classPathBinder.bindAllSingletons("org.opendaylight.genius.alivenessmonitor", binder());
+        super(classPathBinder, "org.opendaylight.genius.alivenessmonitor");
     }
 }

--- a/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
+++ b/src/main/java/org/opendaylight/genius/simple/AlivenessMonitorWiring.java
@@ -9,7 +9,6 @@ package org.opendaylight.genius.simple;
 
 import com.google.inject.AbstractModule;
 import org.opendaylight.infrautils.inject.guice.GuiceClassPathBinder;
-import org.opendaylight.yang.gen.v1.urn.opendaylight.genius.alivenessmonitor.rev160411.AlivenessMonitorService;
 
 public class AlivenessMonitorWiring extends AbstractModule {
 
@@ -21,7 +20,6 @@ public class AlivenessMonitorWiring extends AbstractModule {
 
     @Override
     protected void configure() {
-        classPathBinder.bind(binder(), AlivenessMonitorService.class);
+        classPathBinder.bindAllSingletons("org.opendaylight.genius.alivenessmonitor", binder());
     }
-
 }

--- a/src/main/java/org/opendaylight/infrautils/inject/guice/AutoWiringModule.java
+++ b/src/main/java/org/opendaylight/infrautils/inject/guice/AutoWiringModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc. and others. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.opendaylight.infrautils.inject.guice;
+
+import com.google.inject.AbstractModule;
+import java.util.Optional;
+
+/**
+ * Guice Module with classpath scanning based autowiring.
+ *
+ * @author Michael Vorburger.ch
+ */
+public class AutoWiringModule extends AbstractModule {
+
+    protected final GuiceClassPathBinder classPathBinder;
+    private final Optional<String> packagePrefix;
+
+    public AutoWiringModule(GuiceClassPathBinder classPathBinder, String packagePrefix) {
+        this.classPathBinder = classPathBinder;
+        this.packagePrefix = Optional.of(packagePrefix);
+    }
+
+    protected AutoWiringModule(GuiceClassPathBinder classPathBinder) {
+        this.classPathBinder = classPathBinder;
+        this.packagePrefix = Optional.empty();
+    }
+
+    @Override
+    protected void configure() {
+        packagePrefix.ifPresent(prefix -> classPathBinder.bindAllSingletons(prefix, binder()));
+    }
+}

--- a/src/main/java/org/opendaylight/infrautils/inject/guice/GuiceClassPathBinder.java
+++ b/src/main/java/org/opendaylight/infrautils/inject/guice/GuiceClassPathBinder.java
@@ -29,4 +29,8 @@ public class GuiceClassPathBinder {
     public void bind(Binder binder, Class<?> requestedInterface) {
         scanner.bind((contract, implementation) -> binder.bind(contract).to(implementation), requestedInterface);
     }
+
+    public void bindAllSingletons(String prefix, Binder binder) {
+        scanner.bindAllSingletons(prefix, (contract, implementation) -> binder.bind(contract).to(implementation));
+    }
 }

--- a/src/main/java/org/opendaylight/netvirt/simple/NetvirtWiring.java
+++ b/src/main/java/org/opendaylight/netvirt/simple/NetvirtWiring.java
@@ -7,16 +7,14 @@
  */
 package org.opendaylight.netvirt.simple;
 
-import com.google.inject.AbstractModule;
 import org.opendaylight.genius.simple.GeniusWiring;
+import org.opendaylight.infrautils.inject.guice.AutoWiringModule;
 import org.opendaylight.infrautils.inject.guice.GuiceClassPathBinder;
 
-public class NetvirtWiring extends AbstractModule {
-
-    private final GuiceClassPathBinder classPathBinder;
+public class NetvirtWiring extends AutoWiringModule {
 
     public NetvirtWiring(GuiceClassPathBinder classPathBinder) {
-        this.classPathBinder = classPathBinder;
+        super(classPathBinder);
     }
 
     @Override
@@ -25,5 +23,4 @@ public class NetvirtWiring extends AbstractModule {
 
         install(new AclServiceWiring());
     }
-
 }

--- a/src/test/java/org/opendaylight/infrautils/inject/tests/ClassPathScannerTest.java
+++ b/src/test/java/org/opendaylight/infrautils/inject/tests/ClassPathScannerTest.java
@@ -11,21 +11,26 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 import org.opendaylight.infrautils.inject.ClassPathScanner;
 
 public class ClassPathScannerTest {
-    private final Map<Class<?>, Class<?>> bindings = new HashMap<>();
 
-    @Before
-    public void setup() {
-        new ClassPathScanner("org.opendaylight.infrautils.inject.tests").bind(bindings::put,
-            ClassPathScannerTestTopInterface.class);
+    private static final String PREFIX = "org.opendaylight.infrautils.inject.tests";
+
+    @Test
+    public void testExplicitBinding() {
+        Map<Class<?>, Class<?>> bindings = new HashMap<>();
+        new ClassPathScanner(PREFIX).bind(bindings::put,
+                ClassPathScannerTestTopInterface.class);
+        assertThat(bindings).containsExactly(
+                ClassPathScannerTestTopInterface.class, ClassPathScannerTestImplementation.class);
     }
 
     @Test
-    public void verifyImplementationBinding() {
+    public void testImplicitBinding() {
+        Map<Class<?>, Class<?>> bindings = new HashMap<>();
+        new ClassPathScanner(PREFIX).bindAllSingletons(PREFIX, bindings::put);
         assertThat(bindings).containsExactly(
                 ClassPathScannerTestTopInterface.class, ClassPathScannerTestImplementation.class);
     }


### PR DESCRIPTION
and use it in AlivenessMonitorWiring

This now also wires the HwVtepTunnelsStateHandler, which we forgot! ;)

That (to not forget to manually wire in any @Singleton) is the point.

PS: PacketProcessingListener didn't get wired, just like it should be.