### PR TITLE
switch NeutronModule to be an AutoWiringModule, remove all manual wiring

### DIFF
--- a/src/main/java/org/opendaylight/neutron/simple/NeutronModule.java
+++ b/src/main/java/org/opendaylight/neutron/simple/NeutronModule.java
@@ -7,116 +7,17 @@
  */
 package org.opendaylight.neutron.simple;
 
-import com.google.inject.AbstractModule;
-import org.opendaylight.neutron.northbound.api.WebInitializer;
-import org.opendaylight.neutron.spi.INeutronBgpvpnCRUD;
-import org.opendaylight.neutron.spi.INeutronFirewallCRUD;
-import org.opendaylight.neutron.spi.INeutronFirewallPolicyCRUD;
-import org.opendaylight.neutron.spi.INeutronFirewallRuleCRUD;
-import org.opendaylight.neutron.spi.INeutronFloatingIpCRUD;
-import org.opendaylight.neutron.spi.INeutronL2gatewayCRUD;
-import org.opendaylight.neutron.spi.INeutronL2gatewayConnectionCRUD;
-import org.opendaylight.neutron.spi.INeutronLoadBalancerCRUD;
-import org.opendaylight.neutron.spi.INeutronLoadBalancerHealthMonitorCRUD;
-import org.opendaylight.neutron.spi.INeutronLoadBalancerListenerCRUD;
-import org.opendaylight.neutron.spi.INeutronLoadBalancerPoolCRUD;
-import org.opendaylight.neutron.spi.INeutronMeteringLabelCRUD;
-import org.opendaylight.neutron.spi.INeutronMeteringLabelRuleCRUD;
-import org.opendaylight.neutron.spi.INeutronNetworkCRUD;
-import org.opendaylight.neutron.spi.INeutronPortCRUD;
-import org.opendaylight.neutron.spi.INeutronQosPolicyCRUD;
-import org.opendaylight.neutron.spi.INeutronRouterCRUD;
-import org.opendaylight.neutron.spi.INeutronSFCFlowClassifierCRUD;
-import org.opendaylight.neutron.spi.INeutronSFCPortChainCRUD;
-import org.opendaylight.neutron.spi.INeutronSFCPortPairCRUD;
-import org.opendaylight.neutron.spi.INeutronSFCPortPairGroupCRUD;
-import org.opendaylight.neutron.spi.INeutronSecurityGroupCRUD;
-import org.opendaylight.neutron.spi.INeutronSecurityRuleCRUD;
-import org.opendaylight.neutron.spi.INeutronSubnetCRUD;
-import org.opendaylight.neutron.spi.INeutronTapFlowCRUD;
-import org.opendaylight.neutron.spi.INeutronTapServiceCRUD;
-import org.opendaylight.neutron.spi.INeutronTrunkCRUD;
-import org.opendaylight.neutron.spi.INeutronVpnIkePolicyCRUD;
-import org.opendaylight.neutron.spi.INeutronVpnIpSecPolicyCRUD;
-import org.opendaylight.neutron.spi.INeutronVpnIpSecSiteConnectionsCRUD;
-import org.opendaylight.neutron.spi.INeutronVpnServiceCRUD;
-import org.opendaylight.neutron.transcriber.NeutronBgpvpnInterface;
-import org.opendaylight.neutron.transcriber.NeutronFirewallInterface;
-import org.opendaylight.neutron.transcriber.NeutronFirewallPolicyInterface;
-import org.opendaylight.neutron.transcriber.NeutronFirewallRuleInterface;
-import org.opendaylight.neutron.transcriber.NeutronFloatingIpInterface;
-import org.opendaylight.neutron.transcriber.NeutronL2gatewayConnectionInterface;
-import org.opendaylight.neutron.transcriber.NeutronL2gatewayInterface;
-import org.opendaylight.neutron.transcriber.NeutronLoadBalancerHealthMonitorInterface;
-import org.opendaylight.neutron.transcriber.NeutronLoadBalancerInterface;
-import org.opendaylight.neutron.transcriber.NeutronLoadBalancerListenerInterface;
-import org.opendaylight.neutron.transcriber.NeutronLoadBalancerPoolInterface;
-import org.opendaylight.neutron.transcriber.NeutronMeteringLabelInterface;
-import org.opendaylight.neutron.transcriber.NeutronMeteringLabelRuleInterface;
-import org.opendaylight.neutron.transcriber.NeutronNetworkInterface;
-import org.opendaylight.neutron.transcriber.NeutronPortInterface;
-import org.opendaylight.neutron.transcriber.NeutronQosPolicyInterface;
-import org.opendaylight.neutron.transcriber.NeutronRouterInterface;
-import org.opendaylight.neutron.transcriber.NeutronSFCFlowClassifierInterface;
-import org.opendaylight.neutron.transcriber.NeutronSFCPortChainInterface;
-import org.opendaylight.neutron.transcriber.NeutronSFCPortPairGroupInterface;
-import org.opendaylight.neutron.transcriber.NeutronSFCPortPairInterface;
-import org.opendaylight.neutron.transcriber.NeutronSecurityGroupInterface;
-import org.opendaylight.neutron.transcriber.NeutronSecurityRuleInterface;
-import org.opendaylight.neutron.transcriber.NeutronSubnetInterface;
-import org.opendaylight.neutron.transcriber.NeutronTapFlowInterface;
-import org.opendaylight.neutron.transcriber.NeutronTapServiceInterface;
-import org.opendaylight.neutron.transcriber.NeutronTrunkInterface;
-import org.opendaylight.neutron.transcriber.NeutronVpnIkePolicyInterface;
-import org.opendaylight.neutron.transcriber.NeutronVpnIpSecPolicyInterface;
-import org.opendaylight.neutron.transcriber.NeutronVpnIpSecSiteConnectionsInterface;
-import org.opendaylight.neutron.transcriber.NeutronVpnServiceInterface;
+import org.opendaylight.infrautils.inject.guice.AutoWiringModule;
+import org.opendaylight.infrautils.inject.guice.GuiceClassPathBinder;
 
 /**
  * Guice module for Neutron.
  *
  * @author Michael Vorburger.ch
  */
-public class NeutronModule extends AbstractModule {
+public class NeutronModule extends AutoWiringModule {
 
-    @Override
-    protected void configure() {
-        bind(WebInitializer.class);
-
-        // The following is currently copy/pasted from
-        // org.opendaylight.neutron.e2etest.NeutronTestWiring
-        // but likely will get replaced with automated classpath scanning anyway later
-        // (strangely though it needs  everywhere, only here)
-        bind(INeutronNetworkCRUD.class).to(NeutronNetworkInterface.class);
-        bind(INeutronSubnetCRUD.class).to(NeutronSubnetInterface.class);
-        bind(INeutronPortCRUD.class).to(NeutronPortInterface.class);
-        bind(INeutronRouterCRUD.class).to(NeutronRouterInterface.class);
-        bind(INeutronFloatingIpCRUD.class).to(NeutronFloatingIpInterface.class);
-        bind(INeutronSecurityGroupCRUD.class).to(NeutronSecurityGroupInterface.class);
-        bind(INeutronSecurityRuleCRUD.class).to(NeutronSecurityRuleInterface.class);
-        bind(INeutronFirewallCRUD.class).to(NeutronFirewallInterface.class);
-        bind(INeutronFirewallPolicyCRUD.class).to(NeutronFirewallPolicyInterface.class);
-        bind(INeutronFirewallRuleCRUD.class).to(NeutronFirewallRuleInterface.class);
-        bind(INeutronLoadBalancerCRUD.class).to(NeutronLoadBalancerInterface.class);
-        bind(INeutronLoadBalancerListenerCRUD.class).to(NeutronLoadBalancerListenerInterface.class);
-        bind(INeutronLoadBalancerPoolCRUD.class).to(NeutronLoadBalancerPoolInterface.class);
-        bind(INeutronBgpvpnCRUD.class).to(NeutronBgpvpnInterface.class);
-        bind(INeutronL2gatewayCRUD.class).to(NeutronL2gatewayInterface.class);
-        bind(INeutronL2gatewayConnectionCRUD.class).to(NeutronL2gatewayConnectionInterface.class);
-        bind(INeutronLoadBalancerHealthMonitorCRUD.class).to(NeutronLoadBalancerHealthMonitorInterface.class);
-        bind(INeutronMeteringLabelCRUD.class).to(NeutronMeteringLabelInterface.class);
-        bind(INeutronMeteringLabelRuleCRUD.class).to(NeutronMeteringLabelRuleInterface.class);
-        bind(INeutronVpnServiceCRUD.class).to(NeutronVpnServiceInterface.class);
-        bind(INeutronVpnIkePolicyCRUD.class).to(NeutronVpnIkePolicyInterface.class);
-        bind(INeutronVpnIpSecPolicyCRUD.class).to(NeutronVpnIpSecPolicyInterface.class);
-        bind(INeutronSFCFlowClassifierCRUD.class).to(NeutronSFCFlowClassifierInterface.class);
-        bind(INeutronSFCPortChainCRUD.class).to(NeutronSFCPortChainInterface.class);
-        bind(INeutronSFCPortPairGroupCRUD.class).to(NeutronSFCPortPairGroupInterface.class);
-        bind(INeutronSFCPortPairCRUD.class).to(NeutronSFCPortPairInterface.class);
-        bind(INeutronQosPolicyCRUD.class).to(NeutronQosPolicyInterface.class);
-        bind(INeutronTrunkCRUD.class).to(NeutronTrunkInterface.class);
-        bind(INeutronTapServiceCRUD.class).to(NeutronTapServiceInterface.class);
-        bind(INeutronTapFlowCRUD.class).to(NeutronTapFlowInterface.class);
-        bind(INeutronVpnIpSecSiteConnectionsCRUD.class).to(NeutronVpnIpSecSiteConnectionsInterface.class);
+    public NeutronModule(GuiceClassPathBinder classPathBinder) {
+        super(classPathBinder, "org.opendaylight.neutron");
     }
 }

--- a/src/test/java/org/opendaylight/neutron/simple/test/NeutronModuleTest.java
+++ b/src/test/java/org/opendaylight/neutron/simple/test/NeutronModuleTest.java
@@ -16,6 +16,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.opendaylight.aaa.web.WebServer;
 import org.opendaylight.controller.simple.InMemoryControllerModule;
+import org.opendaylight.infrautils.inject.guice.GuiceClassPathBinder;
 import org.opendaylight.infrautils.inject.guice.testutils.AnnotationsModule;
 import org.opendaylight.infrautils.inject.guice.testutils.GuiceRule2;
 import org.opendaylight.infrautils.simple.testutils.AbstractSimpleDistributionTest;
@@ -30,8 +31,10 @@ import org.opendaylight.neutron.simple.NeutronModule;
  */
 public class NeutronModuleTest extends AbstractSimpleDistributionTest {
 
-    public @Rule GuiceRule2 guice = new GuiceRule2(
-            NeutronModule.class, InMemoryControllerModule.class, WebModule.class, AnnotationsModule.class);
+    private static final GuiceClassPathBinder CLASS_PATH_BINDER = new GuiceClassPathBinder("org.opendaylight");
+
+    public @Rule GuiceRule2 guice = new GuiceRule2(new NeutronModule(CLASS_PATH_BINDER),
+            new InMemoryControllerModule(), new WebModule(), new AnnotationsModule());
 
     @Inject WebServer webServer;
     @Inject TestHttpClient http;


### PR DESCRIPTION
This doesn't quite work yet because:

1) No implementation for org.opendaylight.netconf.sal.restconf.api.JSONRestconfService was bound.
   This is a mess, requiring full/partial NetConf support, huh?!

2) No implementation for org.opendaylight.yang.gen.v1.urn.opendaylight.neutron.northbound.api.config.rev181024.NeutronNorthboundApiConfig was bound.
   This is easy to fix using ConfigReader.